### PR TITLE
Reduce cyclomatic complexity in main() and ParseSNMPResponse()

### DIFF
--- a/discovery/parser.go
+++ b/discovery/parser.go
@@ -36,6 +36,107 @@ type SwitchLLDP struct {
 	Interfaces []InterfaceInfo
 }
 
+// extractSysDescr extracts the sysDescr label from the metric families.
+func extractSysDescr(families map[string]*dto.MetricFamily) string {
+	mf, ok := families["sysDescr"]
+	if !ok {
+		return ""
+	}
+	for _, m := range mf.GetMetric() {
+		if m.GetGauge() != nil || m.GetUntyped() != nil {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "sysDescr" {
+					return lp.GetValue()
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// extractLLDPNeighbors extracts all LLDP neighbor data from the metric families.
+func extractLLDPNeighbors(families map[string]*dto.MetricFamily) []LLDPNeighbor {
+	neighborMap := make(map[string]*LLDPNeighbor)
+
+	extractLLDPLabels(families, "lldpRemSysName", neighborMap, func(n *LLDPNeighbor, labels map[string]string) {
+		n.RemoteSysName = labels["lldpRemSysName"]
+	})
+	extractLLDPLabels(families, "lldpRemPortId", neighborMap, func(n *LLDPNeighbor, labels map[string]string) {
+		n.RemotePortID = labels["lldpRemPortId"]
+	})
+	extractLLDPLabels(families, "lldpRemPortDesc", neighborMap, func(n *LLDPNeighbor, labels map[string]string) {
+		n.RemotePortDesc = labels["lldpRemPortDesc"]
+	})
+	extractLLDPLabels(families, "lldpRemSysDesc", neighborMap, func(n *LLDPNeighbor, labels map[string]string) {
+		n.RemoteSysDesc = labels["lldpRemSysDesc"]
+	})
+	extractLLDPLabels(families, "lldpLocPortId", neighborMap, func(n *LLDPNeighbor, labels map[string]string) {
+		n.LocalPortID = labels["lldpLocPortId"]
+	})
+	extractLLDPLabels(families, "lldpLocPortDesc", neighborMap, func(n *LLDPNeighbor, labels map[string]string) {
+		n.LocalPortDesc = labels["lldpLocPortDesc"]
+	})
+
+	var neighbors []LLDPNeighbor
+	for _, n := range neighborMap {
+		neighbors = append(neighbors, *n)
+	}
+	return neighbors
+}
+
+// getOrCreateIF returns the InterfaceInfo for the given index, creating it if needed.
+func getOrCreateIF(ifMap map[string]*InterfaceInfo, idx string) *InterfaceInfo {
+	if iface, ok := ifMap[idx]; ok {
+		return iface
+	}
+	iface := &InterfaceInfo{Index: idx}
+	ifMap[idx] = iface
+	return iface
+}
+
+// extractInterfaces extracts IF-MIB interface information from the metric families.
+func extractInterfaces(families map[string]*dto.MetricFamily) []InterfaceInfo {
+	ifMap := make(map[string]*InterfaceInfo)
+
+	if mf, ok := families["ifDescr"]; ok {
+		for _, m := range mf.GetMetric() {
+			labels := labelMap(m)
+			if idx := labels["ifIndex"]; idx != "" {
+				getOrCreateIF(ifMap, idx).Descr = labels["ifDescr"]
+			}
+		}
+	}
+
+	if mf, ok := families["ifOperStatus"]; ok {
+		for _, m := range mf.GetMetric() {
+			labels := labelMap(m)
+			if idx := labels["ifIndex"]; idx != "" {
+				iface := getOrCreateIF(ifMap, idx)
+				if metricValue(m) == 1 {
+					iface.OperStatus = "up"
+				} else {
+					iface.OperStatus = "down"
+				}
+			}
+		}
+	}
+
+	if mf, ok := families["ifAlias"]; ok {
+		for _, m := range mf.GetMetric() {
+			labels := labelMap(m)
+			if idx := labels["ifIndex"]; idx != "" {
+				getOrCreateIF(ifMap, idx).Alias = labels["ifAlias"]
+			}
+		}
+	}
+
+	var interfaces []InterfaceInfo
+	for _, iface := range ifMap {
+		interfaces = append(interfaces, *iface)
+	}
+	return interfaces
+}
+
 // ParseSNMPResponse parses Prometheus text format response from the SNMP exporter
 // into structured LLDP and interface data.
 func ParseSNMPResponse(body []byte, switchName string) (*SwitchLLDP, error) {
@@ -45,119 +146,12 @@ func ParseSNMPResponse(body []byte, switchName string) (*SwitchLLDP, error) {
 		return nil, fmt.Errorf("parse prometheus text format: %w", err)
 	}
 
-	result := &SwitchLLDP{
-		SysName: switchName,
-	}
-
-	// Extract sysDescr
-	if mf, ok := families["sysDescr"]; ok {
-		for _, m := range mf.GetMetric() {
-			if m.GetGauge() != nil || m.GetUntyped() != nil {
-				for _, lp := range m.GetLabel() {
-					if lp.GetName() == "sysDescr" {
-						result.SysDesc = lp.GetValue()
-					}
-				}
-			}
-		}
-	}
-
-	// Extract LLDP neighbor data
-	// SNMP exporter exposes these with labels containing the LLDP info
-	neighborMap := make(map[string]*LLDPNeighbor)
-
-	// lldpRemSysName - remote system name
-	extractLLDPLabels(families, "lldpRemSysName", neighborMap, func(n *LLDPNeighbor, labels map[string]string) {
-		n.RemoteSysName = labels["lldpRemSysName"]
-	})
-
-	// lldpRemPortId - remote port ID
-	extractLLDPLabels(families, "lldpRemPortId", neighborMap, func(n *LLDPNeighbor, labels map[string]string) {
-		n.RemotePortID = labels["lldpRemPortId"]
-	})
-
-	// lldpRemPortDesc - remote port description
-	extractLLDPLabels(families, "lldpRemPortDesc", neighborMap, func(n *LLDPNeighbor, labels map[string]string) {
-		n.RemotePortDesc = labels["lldpRemPortDesc"]
-	})
-
-	// lldpRemSysDesc - remote system description
-	extractLLDPLabels(families, "lldpRemSysDesc", neighborMap, func(n *LLDPNeighbor, labels map[string]string) {
-		n.RemoteSysDesc = labels["lldpRemSysDesc"]
-	})
-
-	// lldpLocPortId - local port ID (may also help identify the local port)
-	extractLLDPLabels(families, "lldpLocPortId", neighborMap, func(n *LLDPNeighbor, labels map[string]string) {
-		n.LocalPortID = labels["lldpLocPortId"]
-	})
-
-	// lldpLocPortDesc - local port description
-	extractLLDPLabels(families, "lldpLocPortDesc", neighborMap, func(n *LLDPNeighbor, labels map[string]string) {
-		n.LocalPortDesc = labels["lldpLocPortDesc"]
-	})
-
-	for _, n := range neighborMap {
-		result.Neighbors = append(result.Neighbors, *n)
-	}
-
-	// Extract interface information from IF-MIB
-	ifMap := make(map[string]*InterfaceInfo)
-
-	// ifDescr
-	if mf, ok := families["ifDescr"]; ok {
-		for _, m := range mf.GetMetric() {
-			labels := labelMap(m)
-			idx := labels["ifIndex"]
-			if idx == "" {
-				continue
-			}
-			if _, ok := ifMap[idx]; !ok {
-				ifMap[idx] = &InterfaceInfo{Index: idx}
-			}
-			ifMap[idx].Descr = labels["ifDescr"]
-		}
-	}
-
-	// ifOperStatus - 1=up, 2=down
-	if mf, ok := families["ifOperStatus"]; ok {
-		for _, m := range mf.GetMetric() {
-			labels := labelMap(m)
-			idx := labels["ifIndex"]
-			if idx == "" {
-				continue
-			}
-			if _, ok := ifMap[idx]; !ok {
-				ifMap[idx] = &InterfaceInfo{Index: idx}
-			}
-			val := metricValue(m)
-			if val == 1 {
-				ifMap[idx].OperStatus = "up"
-			} else {
-				ifMap[idx].OperStatus = "down"
-			}
-		}
-	}
-
-	// ifAlias
-	if mf, ok := families["ifAlias"]; ok {
-		for _, m := range mf.GetMetric() {
-			labels := labelMap(m)
-			idx := labels["ifIndex"]
-			if idx == "" {
-				continue
-			}
-			if _, ok := ifMap[idx]; !ok {
-				ifMap[idx] = &InterfaceInfo{Index: idx}
-			}
-			ifMap[idx].Alias = labels["ifAlias"]
-		}
-	}
-
-	for _, iface := range ifMap {
-		result.Interfaces = append(result.Interfaces, *iface)
-	}
-
-	return result, nil
+	return &SwitchLLDP{
+		SysName:    switchName,
+		SysDesc:    extractSysDescr(families),
+		Neighbors:  extractLLDPNeighbors(families),
+		Interfaces: extractInterfaces(families),
+	}, nil
 }
 
 // extractLLDPLabels extracts LLDP neighbor data from a metric family.

--- a/main.go
+++ b/main.go
@@ -31,6 +31,117 @@ func securityHeadersMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// parseLogLevel converts a log level string to the corresponding slog.Level.
+func parseLogLevel(s string) slog.Level {
+	switch strings.ToLower(s) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// envOverride sets dst to the environment variable value if set.
+func envOverride(dst *string, key string) {
+	if v := os.Getenv(key); v != "" {
+		*dst = v
+	}
+}
+
+// envOverridePort sets dst to ":value" from the environment variable if set.
+func envOverridePort(dst *string, key string) {
+	if v := os.Getenv(key); v != "" {
+		*dst = ":" + v
+	}
+}
+
+// setupRoutes registers all HTTP handlers on the given mux.
+func setupRoutes(mux *http.ServeMux, registry *prometheus.Registry, state *discovery.State, logger *slog.Logger) {
+	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{
+		ErrorLog: slog.NewLogLogger(logger.Handler(), slog.LevelError),
+	}))
+
+	mux.HandleFunc("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "OK")
+	})
+	mux.HandleFunc("/-/ready", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "OK")
+	})
+
+	mux.HandleFunc("/api/v1/topology", func(w http.ResponseWriter, r *http.Request) {
+		state.RLock()
+		defer state.RUnlock()
+
+		resp := map[string]interface{}{
+			"switches":          state.Switches,
+			"hosts":             state.Hosts,
+			"links":             state.Links,
+			"last_run_time":     state.LastRunTime,
+			"last_run_duration": state.LastRunDuration.String(),
+			"last_run_success":  state.LastRunSuccess,
+			"run_count":         state.RunCount,
+			"error_count":       state.ErrorCount,
+			"data_age_seconds":  time.Since(state.LastRunTime).Seconds(),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			logger.Error("failed to encode topology response", "error", err)
+		}
+	})
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, `<!DOCTYPE html>
+<html>
+<head><title>Topology Discovery Exporter</title></head>
+<body>
+<h1>Topology Discovery Exporter</h1>
+<p>Version: %s (branch: %s, revision: %s)</p>
+<ul>
+  <li><a href="/metrics">Metrics</a></li>
+  <li><a href="/api/v1/topology">Topology API</a></li>
+  <li><a href="/-/healthy">Health</a></li>
+</ul>
+</body>
+</html>`, version.Version, version.Branch, version.Revision)
+	})
+}
+
+// startDiscoveryLoop runs initial discovery then ticks at the given interval.
+func startDiscoveryLoop(ctx context.Context, cfg *discovery.Config, state *discovery.State, database *db.DB, logger *slog.Logger, interval time.Duration) {
+	logger.Info("running initial topology discovery")
+	if err := discovery.RunDiscovery(cfg, state, database, logger); err != nil {
+		logger.Error("initial discovery failed", "error", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			logger.Info("running scheduled topology discovery")
+			if err := discovery.RunDiscovery(cfg, state, database, logger); err != nil {
+				logger.Error("scheduled discovery failed", "error", err)
+			}
+		case <-ctx.Done():
+			logger.Info("stopping discovery ticker")
+			return
+		}
+	}
+}
+
 func main() {
 	listenAddr := flag.String("web.listen-address", ":10042", "Address to listen on for web interface and telemetry")
 	configFile := flag.String("config.file", "/opt/topology/config.yml", "Path to configuration file")
@@ -45,33 +156,12 @@ func main() {
 	}
 
 	// Environment variable overrides
-	if v := os.Getenv("PORT"); v != "" {
-		*listenAddr = ":" + v
-	}
-	if v := os.Getenv("LOG_LEVEL"); v != "" {
-		*logLevel = v
-	}
-	if v := os.Getenv("CONFIG_FILE"); v != "" {
-		*configFile = v
-	}
-	if v := os.Getenv("DISCOVERY_INTERVAL"); v != "" {
-		*discoveryInterval = v
-	}
+	envOverridePort(listenAddr, "PORT")
+	envOverride(logLevel, "LOG_LEVEL")
+	envOverride(configFile, "CONFIG_FILE")
+	envOverride(discoveryInterval, "DISCOVERY_INTERVAL")
 
-	// Configure structured logging
-	var level slog.Level
-	switch strings.ToLower(*logLevel) {
-	case "debug":
-		level = slog.LevelDebug
-	case "warn":
-		level = slog.LevelWarn
-	case "error":
-		level = slog.LevelError
-	default:
-		level = slog.LevelInfo
-	}
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
-
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: parseLogLevel(*logLevel)}))
 	logger.Info("starting topology discovery exporter", "version", version.Version)
 
 	// Parse discovery interval
@@ -125,7 +215,6 @@ func main() {
 	// Create fresh Prometheus registry (no default Go metrics)
 	registry := prometheus.NewRegistry()
 
-	// Register MasterCollector
 	mc := collector.NewMasterCollector(&collector.Config{
 		Logger:         logger,
 		Hostname:       hostname,
@@ -136,97 +225,13 @@ func main() {
 	// Start background discovery ticker
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	go func() {
-		logger.Info("running initial topology discovery")
-		if err := discovery.RunDiscovery(cfg, state, database, logger); err != nil {
-			logger.Error("initial discovery failed", "error", err)
-		}
-
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				logger.Info("running scheduled topology discovery")
-				if err := discovery.RunDiscovery(cfg, state, database, logger); err != nil {
-					logger.Error("scheduled discovery failed", "error", err)
-				}
-			case <-ctx.Done():
-				logger.Info("stopping discovery ticker")
-				return
-			}
-		}
-	}()
+	go startDiscoveryLoop(ctx, cfg, state, database, logger, interval)
 
 	// HTTP server
 	mux := http.NewServeMux()
-
-	// Metrics endpoint
-	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{
-		ErrorLog: slog.NewLogLogger(logger.Handler(), slog.LevelError),
-	}))
-
-	// Health endpoints
-	mux.HandleFunc("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, "OK")
-	})
-	mux.HandleFunc("/-/ready", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, "OK")
-	})
-
-	// JSON API for current topology
-	mux.HandleFunc("/api/v1/topology", func(w http.ResponseWriter, r *http.Request) {
-		state.RLock()
-		defer state.RUnlock()
-
-		resp := map[string]interface{}{
-			"switches":          state.Switches,
-			"hosts":             state.Hosts,
-			"links":             state.Links,
-			"last_run_time":     state.LastRunTime,
-			"last_run_duration": state.LastRunDuration.String(),
-			"last_run_success":  state.LastRunSuccess,
-			"run_count":         state.RunCount,
-			"error_count":       state.ErrorCount,
-			"data_age_seconds":  time.Since(state.LastRunTime).Seconds(),
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			logger.Error("failed to encode topology response", "error", err)
-		}
-	})
-
-	// Landing page
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/" {
-			http.NotFound(w, r)
-			return
-		}
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		fmt.Fprintf(w, `<!DOCTYPE html>
-<html>
-<head><title>Topology Discovery Exporter</title></head>
-<body>
-<h1>Topology Discovery Exporter</h1>
-<p>Version: %s (branch: %s, revision: %s)</p>
-<ul>
-  <li><a href="/metrics">Metrics</a></li>
-  <li><a href="/api/v1/topology">Topology API</a></li>
-  <li><a href="/-/healthy">Health</a></li>
-</ul>
-</body>
-</html>`, version.Version, version.Branch, version.Revision)
-	})
-
-	// Wrap mux with security headers middleware
+	setupRoutes(mux, registry, state, logger)
 	handler := securityHeadersMiddleware(mux)
 
-	// Graceful shutdown
 	server := &http.Server{
 		Addr:              *listenAddr,
 		Handler:           handler,


### PR DESCRIPTION
  Extract helper functions to bring gocyclo complexity under 15:

  main.go: parseLogLevel, envOverride, envOverridePort, setupRoutes,
  startDiscoveryLoop

  discovery/parser.go: extractSysDescr, extractLLDPNeighbors,
  getOrCreateIF, extractInterfaces